### PR TITLE
[WYSYWYG] Correct `Link` extension configuration

### DIFF
--- a/apps/flowbite-svelte-texteditor/src/lib/TextEditor.svelte
+++ b/apps/flowbite-svelte-texteditor/src/lib/TextEditor.svelte
@@ -116,6 +116,7 @@
     codeOptions,
     highlightOptions,
     italicOptions,
+    linkOptions,
     strikeOptions,
     subscriptOptions,
     superscriptOptions,
@@ -254,7 +255,7 @@
         Italic.configure(italicOptions || {}),
         Link.configure({
           openOnClick: false,
-          ...(italicOptions || {})
+          ...(linkOptions || {})
         }),
         Strike.configure(strikeOptions || {}),
         Subscript.configure(subscriptOptions || {}),


### PR DESCRIPTION
## 📑 Description
Correct `Link` extension configuration for the `@tiptap/extension-link`:
The `Link` extension was being configured using italicOptions rather than linkOptions

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable link options to the editor extension configuration.

* **Bug Fixes**
  * Corrected the Link extension to use the proper link configuration options for accurate customization of link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->