### PR TITLE
Use `import type` for type-only imports rather than `import {type }` (Vite 8 / Rolldown compatibility)

### DIFF
--- a/apps/flowbite-svelte-texteditor/src/lib/drag-handle/DragHandle.svelte
+++ b/apps/flowbite-svelte-texteditor/src/lib/drag-handle/DragHandle.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import type { Node } from '@tiptap/pm/model';
   import type { Editor } from '@tiptap/core';
-  import { type DragHandleProps } from '$lib';
+  import type { DragHandleProps } from '$lib';
   import { DragHandlePlugin, dragHandlePluginDefaultKey } from '@tiptap/extension-drag-handle';
 
   // Accept editor and draghandleprops as separate props

--- a/apps/flowbite-svelte-texteditor/src/lib/font/FontButton.svelte
+++ b/apps/flowbite-svelte-texteditor/src/lib/font/FontButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Tooltip, Dropdown, DropdownItem } from 'flowbite-svelte';
   import { setFontFamily, setFontSize, removeFontSizeFormatting, setTextColor, removeTextColorFormatting, generateButtonId, useEditableContext } from '$lib';
-  import { type FontButtonProps } from '$lib/types';
+  import type { FontButtonProps } from '$lib/types';
 
   let { editor, format, tooltipText, ariaLabel, colorValue = '#e66465', id, class: className }: FontButtonProps = $props();
 

--- a/apps/flowbite-svelte-texteditor/src/lib/types.ts
+++ b/apps/flowbite-svelte-texteditor/src/lib/types.ts
@@ -1,5 +1,5 @@
 import type { Editor, FocusPosition } from '@tiptap/core';
-import { type ClassValue } from 'clsx';
+import type { ClassValue } from 'clsx';
 import type { Snippet } from 'svelte';
 import type { HTMLButtonAttributes, HTMLAttributes } from 'svelte/elements';
 import type { BlockquoteOptions } from '@tiptap/extension-blockquote';

--- a/apps/flowbite-svelte-texteditor/src/lib/useEditableContext.svelte.ts
+++ b/apps/flowbite-svelte-texteditor/src/lib/useEditableContext.svelte.ts
@@ -1,6 +1,6 @@
 // lib/utils/useEditableContext.svelte.ts
 import { getContext } from 'svelte';
-import { type ClassValue } from 'clsx';
+import type { ClassValue } from 'clsx';
 import { cn, type EditableContext } from '$lib';
 
 export function useEditableContext() {

--- a/apps/flowbite-svelte-texteditor/src/lib/utils.ts
+++ b/apps/flowbite-svelte-texteditor/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { type BubbleMenuConfig, type FloatingMenuConfig } from '$lib';
+import type { BubbleMenuConfig, FloatingMenuConfig } from '$lib';
 
 /**
  * Combines clsx and tailwind-merge for intelligent class merging


### PR DESCRIPTION
Amends type-only imports using `import { type X }` to use `import type { X }`, which provides a better hint to the compiler that this import can be erased during compilation. This fixes a compatibility issue introduced by Vite 8 changing to `rolldown`.

Without it, `import {} from './'` is generated, and rolldown chokes on this ("UNLOADABLE_DEPENDENCY").

([TS docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#:~:text=While%20TypeScript%20might%20be%20able%20to%20make%20these%20emit%20decisions%20based%20on%20information%20from%20across%20files) are a little vague about the ability to erase without the `import type` hint)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized import statements across the text editor components to use type-only imports, improving TypeScript compilation efficiency and code quality without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->